### PR TITLE
Comments, highlighting, and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.xpr
+sha/

--- a/XSLT/readingView.xsl
+++ b/XSLT/readingView.xsl
@@ -75,11 +75,11 @@
                     <xsl:text>textInsult</xsl:text>
                 </xsl:attribute>
                 <xsl:attribute name="id">
-                    <xsl:value-of select="count(preceding::node()[name() = 'insultStart'])"/>
+                    <xsl:value-of select="count(preceding::node()[name() eq 'insultStart'])"/>
                 </xsl:attribute>
             </xsl:if>
             <xsl:value-of
-                select="string-join(node()[name() ne 'stage']) => normalize-space() => replace(' ([.,:;?!])', '$1')"
+                select="string-join(node()[name() = ('punc', 'w')]) => normalize-space() => replace(' ([.,:;?!])', '$1')"
             />
         </p>
     </xsl:template>

--- a/XSLT/readingView.xsl
+++ b/XSLT/readingView.xsl
@@ -83,4 +83,9 @@
             />
         </p>
     </xsl:template>
+    <xsl:template match="comment()">
+        <xsl:comment>
+            <xsl:value-of select=".">
+        </xsl:comment>
+    </xsl:template>
 </xsl:stylesheet>

--- a/webContent/CSS/index.css
+++ b/webContent/CSS/index.css
@@ -396,7 +396,7 @@ details.sort > p, details.sort > details > details > p {
     flex-direction: column;
     border: 2px solid black;
     background-color: #B80003;
-    width: 22.5%;
+    width: 17.5%;
     margin-right: 2.5%;
     height: min-content;
     margin-left: .5%;

--- a/webContent/CSS/index.css
+++ b/webContent/CSS/index.css
@@ -45,6 +45,7 @@
     --backgroundColor: #2C2A25;
     --headerColor: #8F0002;
     --hoverColor: #B80003;
+    --graphBlue: #5d81b9;
 }
 /* 
  * Default element styling below
@@ -340,6 +341,9 @@ details.sort > p, details.sort > details > details > p {
 .textInsult {
     display: table;
     background-color: var(--headerColor)
+}
+.textInsult:target {
+    background-color: var(--graphBlue)
 }
 /* 
  * Id styling below


### PR DESCRIPTION
# Pull Request 2022-07-29

## XSLT
- When generating the reading views, comments were being added to the text, changed the XSLT so that they are ignored.

## CSS
- Changed the spacing for the insult sort box so that there is more space for the insults themselves
- Inserted target highlighting so that you can clearly tell which insult you wanted to see

## .gitignore
- Set it to ignore the original wordHoard Shakespeare texts folder